### PR TITLE
feature: log death context for heatmap analysis

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -69,6 +69,7 @@ MACRO_CONFIG_INT(InfCaptcha, inf_captcha, 0, 0, 1, CFGFLAG_SERVER, "Enable captc
 MACRO_CONFIG_INT(InfShockwaveAffectHumans, inf_shock_wave_affect_humans, 1, 0, 1, CFGFLAG_SERVER, "Explosion shockwave affect humans")
 MACRO_CONFIG_INT(InfSpawnProtectionTime, inf_spawn_protection_time, 2, 0, 60, CFGFLAG_SERVER, "Time zombies stay invincible while spawning")
 MACRO_CONFIG_INT(InfAntiFireTime, inf_anti_fire_time, 700, 0, 10000, CFGFLAG_SERVER, "Time players can't attack after spawning (in ms)")
+MACRO_CONFIG_INT(InfLogDeathContext, InfLogDeathContext, 1, 0, 1, CFGFLAG_SERVER, "Log information about human death events")
 
 MACRO_CONFIG_INT(InfDefenderLimit, inf_defender_limit, 40, 0, 64, CFGFLAG_SERVER, "Maximum number of defenders in game")
 MACRO_CONFIG_INT(InfMedicLimit, inf_medic_limit, 20, 0, 64, CFGFLAG_SERVER, "Maximum number of medics in game")

--- a/src/game/server/infclass/entities/infccharacter.cpp
+++ b/src/game/server/infclass/entities/infccharacter.cpp
@@ -603,6 +603,13 @@ bool CInfClassCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon, T
 /* INFECTION MODIFICATION START ***************************************/
 	if(Mode == TAKEDAMAGEMODE_INFECTION)
 	{
+		// log the context of a human-type death (purpose: death heatmap analysis)
+		// dev note: this method has to run before the human is infected!
+		if(g_Config.m_InfLogDeathContext&& m_pPlayer->IsHuman())
+		{
+			GameController()->LogDeathContext(m_pPlayer->GetCID());
+		}
+		
 		m_pPlayer->Infect(pKillerPlayer);
 
 		char aBuf[256];

--- a/src/game/server/infclass/infcgamecontroller.cpp
+++ b/src/game/server/infclass/infcgamecontroller.cpp
@@ -1271,6 +1271,21 @@ bool CInfClassGameController::AreTurretsEnabled() const
 	 return Server()->GetActivePlayerCount() >= Config()->m_InfMinPlayersForTurrets;
 }
 
+void CInfClassGameController::LogDeathContext(int ClientID) const
+{
+	if (m_RoundStarted)
+	{
+		int aliveTime = GameServer()->GetPlayer(ClientID)->m_HumanTime / ((float)Server()->TickSpeed());
+		vec2 pos = GameServer()->GetPlayer(ClientID)->GetCharacter()->GetPos();
+
+		char aBuf[256];
+		str_format(aBuf, sizeof(aBuf), "deathContext: mapName=%s lifetime=%d pos_x=%d pos_y=%d",
+				   g_Config.m_SvMap, aliveTime, static_cast<int>(pos.x), static_cast<int>(pos.y)
+		);
+		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+	}
+}
+
 void CInfClassGameController::Snap(int SnappingClient)
 {
 	CNetObj_GameInfo *pGameInfoObj = (CNetObj_GameInfo *)Server()->SnapNewItem(NETOBJTYPE_GAMEINFO, 0, sizeof(CNetObj_GameInfo));

--- a/src/game/server/infclass/infcgamecontroller.h
+++ b/src/game/server/infclass/infcgamecontroller.h
@@ -63,6 +63,7 @@ public:
 	bool PortalsAvailableForCharacter(class CCharacter *pCharacter) override;
 	bool CanJoinTeam(int Team, int ClientID) override;
 	bool AreTurretsEnabled() const;
+	void LogDeathContext(int ClientID) const;
 
 	void ResetFinalExplosion();
 	void SaveRoundRules();


### PR DESCRIPTION
I made the changes you recommended.
Due to recent changes to the class structure and file tree I rebased my changes into another branch `dev_teoman002_heatmap_v2`
The old branch `dev_teoman002_heatmap` can be removed.

**Requested changes:**
- Put `LogDeathContext()` into `CInfClassGameController` 
- Call `LogDeathContext()` from `CInfClassCharacter`
- Use `CInfClassCharacter::GetPos()`
- Use private variable `m_RoundStarted` from `CInfClassGameController` instead of `IsRoundStarted()`

**Additional changes:**
- added a config var `InfLogDeathContext`

**Optional todo**
- changes to the stats parser and log message
