### PR TITLE
Fix the crash caused by out-of-bounds writes in survival mode (with lua)

### DIFF
--- a/src/game/server/infclass/ic_gamecontroller.cpp
+++ b/src/game/server/infclass/ic_gamecontroller.cpp
@@ -2770,6 +2770,12 @@ SurvivalBotConfiguration *CIcGameController::SurvivalAddBot(int Wave, const char
 		return nullptr;
 	}
 
+	if(pConf->BotConfigurations.Size() >= pConf->BotConfigurations.Capacity())
+	{
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "SurvivalAddBot: Too many bots");
+		return nullptr;
+	}
+
 	pConf->BotConfigurations.Add(SurvivalBotConfiguration{.Class = PlayerClass});
 
 	return &pConf->BotConfigurations.Last();


### PR DESCRIPTION
The bug manifests as follows: when a Witch is present and Lua is used, a rare SIGILL occurs in Debug builds, while SIGSEGV occurs frequently in Release builds.

https://github.com/infclass/teeworlds-infclassR/blob/0f94bcbd94741c5135c47c9935574a3553d86e7d/src/game/server/infclass/ic_gamecontroller.cpp#L2773 and icArray::Add lack bounds checking. The CIcGameController::SurvivalAddBot method is frequently called by Lua and similarly lacks bounds checking. When the element count reaches MaxBotsPerWave (128), calling this method causes out-of-bounds writes.